### PR TITLE
docs: fix typo in BoxyId example Size calculation

### DIFF
--- a/website/docs/custom-boxy/boxy-id.md
+++ b/website/docs/custom-boxy/boxy-id.md
@@ -48,7 +48,7 @@ class MyBoxyDelegate extends BoxyDelegate {
 
     // Return the size of our little column.
     return Size(
-      max(helloSize.width, worldSize.height),
+      max(helloSize.width, worldSize.width),
       helloSize.height + worldSize.height,
     );
   }


### PR DESCRIPTION
This PR fixes a small typo in the `BoxyId` documentation example where `worldSize.height` was used instead of `worldSize.width` in the `Size` constructor's width parameter.

Closes #46.