### PR TITLE
Fix unbounded stretch crash, accessibility order, and doc typo (#45, #46, #48)

### DIFF
--- a/boxy/lib/src/boxy/custom_boxy_base.dart
+++ b/boxy/lib/src/boxy/custom_boxy_base.dart
@@ -236,11 +236,9 @@ mixin RenderBoxyMixin<
 
   @override
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
-    for (final child in childHandleMap.values) {
-      if (!child._ignore) {
-        visitor(child.render);
-      }
-    }
+    wrapPhase(BoxyDelegatePhase.semantics, () {
+      delegate.visitChildrenForSemantics(visitor);
+    });
   }
 
   @override
@@ -293,6 +291,9 @@ enum BoxyDelegatePhase {
 
   /// The boxy is currently being hit test.
   hitTest,
+
+  /// Semantics are being visited.
+  semantics,
 }
 
 /// Cache for [Layer] objects, used by [BoxyLayerContext] methods.
@@ -912,6 +913,20 @@ abstract class BaseBoxyDelegate<LayoutData extends Object,
     Listenable? repaint,
   })  : _relayout = relayout,
         _repaint = repaint;
+
+  /// Visits each child that should be included in the semantics tree.
+  ///
+  /// The default behavior is to visit each child that is not [BaseBoxyChild.isIgnored].
+  ///
+  /// This can be overridden to change the order in which children are visited
+  /// for accessibility purposes.
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    for (final child in render.childHandleMap.values) {
+      if (!child.isIgnored) {
+        visitor(child.render);
+      }
+    }
+  }
 
   final Listenable? _relayout;
   final Listenable? _repaint;

--- a/boxy/lib/src/boxy_flex.dart
+++ b/boxy/lib/src/boxy_flex.dart
@@ -1296,7 +1296,8 @@ class RenderBoxyFlex extends RenderBox
           final childConstraints = BoxConstraintsAxisUtil.create(
             _direction,
             minCross:
-                _getCrossAxisAlignment(child) == CrossAxisAlignment.stretch
+                (_getCrossAxisAlignment(child) == CrossAxisAlignment.stretch &&
+                    maxCrossSize.isFinite)
                     ? maxCrossSize
                     : 0.0,
             maxCross: maxCrossSize,
@@ -1343,7 +1344,7 @@ class RenderBoxyFlex extends RenderBox
             if (child == dominantChild) {
               flexConstraints = BoxConstraintsAxisUtil.create(
                 _direction,
-                minCross: maxCrossSize,
+                minCross: maxCrossSize.isFinite ? maxCrossSize : 0.0,
                 maxCross: maxCrossSize,
                 minMain: minChildExtent,
                 maxMain: maxChildExtent,
@@ -1352,7 +1353,8 @@ class RenderBoxyFlex extends RenderBox
               flexConstraints = BoxConstraintsAxisUtil.create(
                 _direction,
                 minCross:
-                    _getCrossAxisAlignment(child) == CrossAxisAlignment.stretch
+                    (_getCrossAxisAlignment(child) == CrossAxisAlignment.stretch &&
+                        maxCrossSize.isFinite)
                         ? maxCrossSize
                         : 0.0,
                 maxCross: maxCrossSize,
@@ -1385,9 +1387,10 @@ class RenderBoxyFlex extends RenderBox
               BoxConstraintsAxisUtil.create(
                 _direction,
                 minCross:
-                    _getCrossAxisAlignment(child) == CrossAxisAlignment.stretch
-                        ? maxCrossSize
-                        : 0.0,
+                    (_getCrossAxisAlignment(child) == CrossAxisAlignment.stretch &&
+                    maxCrossSize.isFinite)
+                    ? maxCrossSize
+                    : 0.0,
                 maxCross: maxCrossSize,
                 minMain: mainSize,
                 maxMain: mainSize,
@@ -1624,6 +1627,36 @@ class RenderBoxyFlex extends RenderBox
           overflowHints: debugOverflowHints);
       return true;
     }());
+  }
+
+  @override
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    _forEachChildWithOrder(visitor);
+  }
+
+  void _forEachChildWithOrder(RenderObjectVisitor visitor) {
+    if (textDirection == null && direction == Axis.horizontal) {
+      return;
+    }
+    final bool flipMainAxis =
+        !(_startIsTopLeft(direction, textDirection, verticalDirection) ?? true);
+    if (flipMainAxis) {
+      RenderBox? child = lastChild;
+      while (child != null) {
+        final FlexParentData childParentData =
+            child.parentData! as FlexParentData;
+        visitor(child);
+        child = childParentData.previousSibling;
+      }
+    } else {
+      RenderBox? child = firstChild;
+      while (child != null) {
+        final FlexParentData childParentData =
+            child.parentData! as FlexParentData;
+        visitor(child);
+        child = childParentData.nextSibling;
+      }
+    }
   }
 
   @override

--- a/website/docs/custom-boxy/boxy-id.md
+++ b/website/docs/custom-boxy/boxy-id.md
@@ -48,7 +48,7 @@ class MyBoxyDelegate extends BoxyDelegate {
 
     // Return the size of our little column.
     return Size(
-      max(helloSize.width, worldSize.height),
+      max(helloSize.width, worldSize.width),
       helloSize.height + worldSize.height,
     );
   }


### PR DESCRIPTION
> [!IMPORTANT]
> This request is being generated by antigravity using gemini-3-flash, and should be viewed with caution.

This pull request addresses several outstanding issues in the `boxy` package:

### Fixes

#### 1. Unbounded Cross-Axis Stretch Crash (#48)
Fixed a layout crash in `RenderBoxyFlex` where `CrossAxisAlignment.stretch` would attempt to apply infinite constraints when the cross-axis was unconstrained. This now mirrors the behavior of Flutter's `RenderFlex`.

#### 2. Accessibility / Semantics Traversal Order (#45)
- Added `visitChildrenForSemantics` to `BaseBoxyDelegate`, allowing delegates to control the order in which children are visited by screen readers.
- Updated `RenderBoxyMixin` to delegate semantics visitation to the delegate (defaulting to visitation of all non-ignored children).
- Implemented visual-order semantics traversal for `RenderBoxyFlex`.
- Added a new `semantics` phase to `BoxyDelegatePhase` to allow safe access to render objects during semantics updates.

#### 3. Documentation Typo in BoxyId Example (#46)
Corrected a copy-paste error in the `BoxyId` documentation where `worldSize.height` was used instead of `worldSize.width` in a `Size` calculation.

### Verification
- Ran existing tests and verified that a reproduction case for the semantics issue now passes.
- Verified the fix for the unbounded stretch crash using a local reproduction test case.

---
Generated by Antigravity.